### PR TITLE
Fix markProcessed race condition

### DIFF
--- a/src/main/scala/px/kinesis/stream/consumer/RecordProcessorImpl.scala
+++ b/src/main/scala/px/kinesis/stream/consumer/RecordProcessorImpl.scala
@@ -31,6 +31,7 @@ class RecordProcessorImpl(
     logging.info("Started consumer.Record Processor {} for Worker: {}",
                  initializationInput.shardId(),
                  workerId)
+    blocking("startingTracker", tracker.start(initializationInput.shardId()))
     shardId = initializationInput.shardId()
   }
 

--- a/src/main/scala/px/kinesis/stream/consumer/checkpoint/CheckpointTracker.scala
+++ b/src/main/scala/px/kinesis/stream/consumer/checkpoint/CheckpointTracker.scala
@@ -98,6 +98,21 @@ class CheckpointTracker(
   }
 
   /**
+    * Creates/starts a tracker for a particular shard.
+    * Should be called when record processor initializes
+    * @param shardId
+    * @return
+    */
+  def start(shardId: String): Future[Done] = {
+    if (!isShutdown) {
+      tracker
+        .ask(Create(shardId))(timeout)
+        .map(_ => Done)
+        .recoverWith(mapAskTimeout("start", shardId))
+    } else Future.successful(Done)
+  }
+
+  /**
     * Shuts down the tracker for a particular shard
     * @param shardId
     * @return

--- a/src/main/scala/px/kinesis/stream/consumer/checkpoint/ShardCheckpointTrackerActor.scala
+++ b/src/main/scala/px/kinesis/stream/consumer/checkpoint/ShardCheckpointTrackerActor.scala
@@ -133,18 +133,23 @@ class ShardCheckpointTrackerActor(shardId: String,
 
 object ShardCheckpointTrackerActor {
   case object Ack
+
+  sealed trait Command
   case class Track(sequenceNumbers: Iterable[ExtendedSequenceNumber])
-  case class Process(sequenceNumber: ExtendedSequenceNumber)
+      extends Command
+  case class Process(sequenceNumber: ExtendedSequenceNumber) extends Command
   case class CheckpointIfNeeded(checkpointer: RecordProcessorCheckpointer,
                                 force: Boolean = false)
+      extends Command
 
   case class Details(tracked: Queue[ExtendedSequenceNumber],
                      checkpointable: Queue[ExtendedSequenceNumber])
   case class Checkpointed(sequenceNumber: Option[ExtendedSequenceNumber] = None)
-  case object WatchCompletion
+
+  case object WatchCompletion extends Command
   case object Completed
-  case object Get
-  case object Shutdown
+  case object Get extends Command
+  case object Shutdown extends Command
 
   def props(shardId: String,
             maxBufferSize: Int,

--- a/src/test/scala/px/kinesis/stream/consumer/checkpoint/CheckpointTrackerActorSpec.scala
+++ b/src/test/scala/px/kinesis/stream/consumer/checkpoint/CheckpointTrackerActorSpec.scala
@@ -84,5 +84,6 @@ class CheckpointTrackerActorSpec
       expectMsg(shard.Ack)
 
     }
+
   }
 }

--- a/src/test/scala/px/kinesis/stream/consumer/checkpoint/CheckpointTrackerActorSpec.scala
+++ b/src/test/scala/px/kinesis/stream/consumer/checkpoint/CheckpointTrackerActorSpec.scala
@@ -1,0 +1,88 @@
+package px.kinesis.stream.consumer.checkpoint
+
+import akka.actor.Status.Failure
+import akka.actor.{ActorRef, ActorSystem}
+import akka.testkit.{ImplicitSender, TestKit}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
+import px.kinesis.stream.consumer.checkpoint.CheckpointTrackerActor._
+import px.kinesis.stream.consumer.checkpoint.{
+  ShardCheckpointTrackerActor => shard
+}
+import software.amazon.kinesis.processor.RecordProcessorCheckpointer
+import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber
+
+import scala.collection.immutable.Seq
+
+class CheckpointTrackerActorSpec
+    extends TestKit(ActorSystem("CheckpointTrackerActorSpec"))
+    with ImplicitSender
+    with FunSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with MockFactory {
+  override def afterAll: Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  val workerId = "123"
+
+  def toSequenceNum(i: Int): ExtendedSequenceNumber =
+    new ExtendedSequenceNumber(i.toString)
+
+  def createTracker(): ActorRef =
+    system.actorOf(
+      CheckpointTrackerActor
+        .props(workerId, 10, 10))
+
+  describe("track") {
+    it("should track successfully after creation of tracker") {
+      val tracker = createTracker()
+      val shardId = "01"
+      tracker ! Create(shardId)
+      expectMsg(Ack)
+
+      tracker ! Track(shardId, Seq(1).map(toSequenceNum))
+      expectMsg(shard.Ack)
+    }
+
+    it("should fail if tracker is not active") {
+      val tracker = createTracker()
+      val shardId = "01"
+      // shard tracker for 01 does not exist
+      tracker ! Track(shardId, Seq(1).map(toSequenceNum))
+      expectMsgPF() {
+        case Failure(_) => true
+      }
+    }
+  }
+
+  describe("process") {
+    it("should process successfully after creation of tracker") {
+      val tracker = createTracker()
+      val shardId = "01"
+      tracker ! Create(shardId)
+      expectMsg(Ack)
+
+      tracker ! Process(shardId, toSequenceNum(1))
+      expectMsg(shard.Ack)
+    }
+
+    it("should process successfully even after shard tracker is shutdown") {
+      val tracker = createTracker()
+      val shardId = "01"
+      tracker ! Create(shardId)
+      expectMsg(Ack)
+
+      tracker ! Process(shardId, toSequenceNum(1))
+      expectMsg(shard.Ack)
+
+      tracker ! Shutdown(shardId)
+      expectMsg(Ack)
+
+      tracker ! Process(shardId, toSequenceNum(2))
+      expectMsg(shard.Ack)
+
+    }
+  }
+}


### PR DESCRIPTION
# Details

This fix addresses an issue where calling a markProcessed method on a record associated with a record processor which has already shutdown due to reasons such as lease lost will cause the stream to hang and eventually fail.

The `Process` message in some edge cases, ends up going to dead letters. In these cases, the `Future` returned by the markProcess call will eventually timeout and fail the client stream.

Fixes #2 

# Solution

- Instead of lazily creating shard tracker actors, create them upon record processor initialization
- Track individual shard tracker actors in a map keyed by shardId
- Automatically Ack Process messages which are received after a shard tracker has been gracefully terminated. The lease for the shard is lost and hence an actual check-pointing is not allowed but we should not fail the stream because of this. Presumably the next processor to get the lease will process these messages again.
- Immediately fail for other calls such as Track, CheckpointIfNeeded, WatchCompletion if a corresponding shard tracker is not active.

