### PR TITLE
Invalid ArtifactID

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A wrapper around KCL 2.x which exposes an Akka Streams source to consume message
 **build.sbt**
 
 ```scala
-libraryDependencies += "com.500px" %% "kinesis-stream" % "0.1.6"
+libraryDependencies += "com.500px" %% "kinesis-stream_2.12" % "0.1.7"
 ```
 
 **note**: Due to java package names not allowing numbers, the import path for the project is `px.kinesis.stream.consumer`.


### PR DESCRIPTION
See: https://github.com/500px/kinesis-stream/issues/8
This PR fixes a typo in the Readme referencing artifact ID `kinesis-stream` when most repositories list it as `kinesis-stream_2.12`.  